### PR TITLE
Saving logs as artifacts in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,6 +101,12 @@ jobs:
           path: target/surefire-reports
       - store_artifacts:
           path: target/surefire-reports
+      - run:
+          command: |
+            mkdir logs
+            mv *.log logs
+      - store_artifacts:
+          path: logs
       - persist_to_workspace:
           root: target
           paths:


### PR DESCRIPTION
This pull request saves the logs of integration tests in CircleCI as artifacts. Therefore they can be viewed in case of test failures.