### PR TITLE
Migrate scenarios to DAML Script (#65)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,20 +162,20 @@ workflows:
   build_and_test:
     jobs:
       - daml_test:
-          daml_sdk_version: "1.4.0"
+          daml_sdk_version: "1.5.0"
       - mvn_test:
-          daml_sdk_version: "1.4.0"
+          daml_sdk_version: "1.5.0"
       - blackduck_check:
-          daml_sdk_version: "1.4.0"
+          daml_sdk_version: "1.5.0"
           context: blackduck
   build_and_release:
     jobs:
       - daml_test:
           <<: *only-release-tags
-          daml_sdk_version: "1.4.0"
+          daml_sdk_version: "1.5.0"
       - mvn_test:
           <<: *only-release-tags
-          daml_sdk_version: "1.4.0"
+          daml_sdk_version: "1.5.0"
           context: blackduck
       - github_release:
           context: github-refapp-repo-context

--- a/Dockerfile-json
+++ b/Dockerfile-json
@@ -2,7 +2,7 @@
 # Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 #
 
-ARG sdk_vsn=1.4.0
+ARG sdk_vsn=1.5.0
 
 FROM digitalasset/daml-sdk:${sdk_vsn}
 

--- a/Dockerfile-navigator
+++ b/Dockerfile-navigator
@@ -2,7 +2,7 @@
 # Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 #
 
-ARG sdk_vsn=1.4.0
+ARG sdk_vsn=1.5.0
 
 FROM digitalasset/daml-sdk:${sdk_vsn}
 

--- a/Dockerfile-sandbox
+++ b/Dockerfile-sandbox
@@ -2,7 +2,7 @@
 # Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 #
 
-ARG sdk_vsn=1.4.0
+ARG sdk_vsn=1.5.0
 
 FROM digitalasset/daml-sdk:${sdk_vsn}
 

--- a/Dockerfile-triggers
+++ b/Dockerfile-triggers
@@ -2,7 +2,7 @@
 # Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 #
 
-ARG sdk_vsn=1.4.0
+ARG sdk_vsn=1.5.0
 
 FROM digitalasset/daml-sdk:${sdk_vsn}
 

--- a/daml.yaml
+++ b/daml.yaml
@@ -21,7 +21,6 @@ dependencies:
   - daml-script
   - daml-trigger
 build-options:
-  - '--target=1.7'
   - '--ghc-option'
   - '-Werror'
   - '--ghc-option'

--- a/daml.yaml
+++ b/daml.yaml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-sdk-version: 1.4.0
+sdk-version: 1.5.0
 name: market-data-service
 source: src/main/daml
 parties:

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <daml-sdk.version>1.4.0</daml-sdk.version>
+        <daml-sdk.version>1.5.0</daml-sdk.version>
         <daml-plugin.version>0.1.4</daml-plugin.version>
         <slf4j.version>1.7.26</slf4j.version>
         <logback.version>1.2.3</logback.version>

--- a/src/main/daml/DA/RefApps/MarketDataService/DataStream.daml
+++ b/src/main/daml/DA/RefApps/MarketDataService/DataStream.daml
@@ -10,6 +10,8 @@ import DA.Foldable
 import DA.TimeService.TimeService
 import DA.Action
 
+import Daml.Script
+
 import DA.RefApps.MarketDataService.MarketDataTypes
 import DA.RefApps.MarketDataService.Publication
 import DA.RefApps.MarketDataService.DataLicense
@@ -164,4 +166,10 @@ getLiveOrExpired operator publisher observationLabel consumer = do
 checkIsExpired : Party -> LicenseData -> Update Bool
 checkIsExpired operator licenseData = do
   currentTime <- fetchTime operator
+  pure $ isLicenseExpired licenseData currentTime
+
+checkIsExpiredScript : Party -> Party -> LicenseData -> Script Bool
+checkIsExpiredScript submitter operator licenseData = do
+  currentTime <- submit submitter do
+    exerciseByKeyCmd @CurrentTime operator (GetCurrentTime submitter)
   pure $ isLicenseExpired licenseData currentTime

--- a/src/main/daml/DA/TimeService/TimeService.daml
+++ b/src/main/daml/DA/TimeService/TimeService.daml
@@ -7,11 +7,16 @@ daml 1.2
 module DA.TimeService.TimeService where
 
 import DA.Time
+import Daml.Script
 
 fetchTime: Party -> Update Time
 fetchTime operator = do
   (_, time) <- fetchByKey @CurrentTime operator
   pure time.currentTime
+
+fetchTimeScript: Party -> Party -> Script Time
+fetchTimeScript submitter operator = do
+  submit submitter $ exerciseByKeyCmd @CurrentTime operator (GetCurrentTime submitter)
 
 template CurrentTime
   with
@@ -26,11 +31,22 @@ template CurrentTime
     key operator: Party
     maintainer key
 
+    nonconsuming choice GetCurrentTime : Time
+      with
+        p : Party
+      controller p
+      do return currentTime
+
     controller operator can
+
       UpdateCurrentTime: ContractId CurrentTime
         with newCurrentTime: Time
         do
           create this with currentTime = newCurrentTime
+
+      nonconsuming AdvanceByCurrentTime: ContractId CurrentTime
+        with delta: RelTime
+        do exercise self (UpdateCurrentTime (addRelTime currentTime delta))
 
       CurrentTime_AddObserver: ContractId CurrentTime
         with newObserver: Party

--- a/src/main/daml/Test/DA/RefApps/MarketDataService/ComplaintsTest.daml
+++ b/src/main/daml/Test/DA/RefApps/MarketDataService/ComplaintsTest.daml
@@ -10,15 +10,18 @@ import DA.Assert
 import DA.TimeService.TimeService
 import DA.Time as T
 
+import Daml.Script
+
 import DA.RefApps.MarketDataService.DataStream
 import DA.RefApps.MarketDataService.DataLicense
 import DA.RefApps.MarketDataService.MarketDataTypes
 import DA.RefApps.MarketDataService.Publication
 
 import Test.DA.RefApps.MarketDataService.RolesTest
+import Test.DA.RefApps.MarketDataService.Utils
 
-testConsumerCanClaimNonPerformance : Scenario ()
-testConsumerCanClaimNonPerformance = scenario do
+testConsumerCanClaimNonPerformance : Script ()
+testConsumerCanClaimNonPerformance = script do
   (reference, currentObservation, operator, endUserParty, mdvCon1Relation, now, afterExpiry, currentTimeCid, mdVendorParty, mdvStreamId, _)
     <- roleSetup
   let
@@ -26,34 +29,33 @@ testConsumerCanClaimNonPerformance = scenario do
     licenseKey = (Publisher mdVendorParty, Consumer endUserParty, reference)
 
   currentTime <- submit operator do
-    exercise currentTimeCid UpdateCurrentTime with newCurrentTime = afterStart
+    exerciseCmd currentTimeCid UpdateCurrentTime with newCurrentTime = afterStart
 
-  submit endUserParty do
-    (licenseId, license) <- fetchByKey @RegisteredDataLicense licenseKey
-    nonPerformanceCid <- exercise licenseId RegisteredDataLicense_ClaimNonPerformance
-    nonPerformance <- fetch nonPerformanceCid
-    nonPerformance.licenseData === license.licenseData
-    nonPerformance.claimed === afterStart
+  Some (licenseId, license) <- queryContractKey @RegisteredDataLicense endUserParty licenseKey
+  nonPerformanceCid <- submit endUserParty do
+    exerciseCmd licenseId RegisteredDataLicense_ClaimNonPerformance
+  Some nonPerformance <- queryContractId endUserParty nonPerformanceCid
+  nonPerformance.licenseData === license.licenseData
+  nonPerformance.claimed === afterStart
 
   submitMustFail mdVendorParty $
-    exercise mdvStreamId StartDataStream with
+    exerciseCmd mdvStreamId StartDataStream with
       newObservation = currentObservation
 
-testConsumerCannotClaimNonPerformanceBeforeStart : Scenario ()
-testConsumerCannotClaimNonPerformanceBeforeStart = scenario do
+testConsumerCannotClaimNonPerformanceBeforeStart : Script ()
+testConsumerCannotClaimNonPerformanceBeforeStart = script do
   (reference, currentObservation, operator, endUserParty, mdvCon1Relation, now, afterExpiry, currentTimeCid, mdVendorParty, mdvStreamId, _)
     <- roleSetup
   let
     licenseKey = (Publisher mdVendorParty, Consumer endUserParty, reference)
 
-  (licenseId, _) <- submit endUserParty do
-    fetchByKey @RegisteredDataLicense licenseKey
+  Some (licenseId, _) <- queryContractKey @RegisteredDataLicense endUserParty licenseKey
 
   submitMustFail endUserParty do
-    exercise licenseId RegisteredDataLicense_ClaimNonPerformance
+    exerciseCmd licenseId RegisteredDataLicense_ClaimNonPerformance
 
-testConsumerCanClaimStalePublication : Scenario ()
-testConsumerCanClaimStalePublication = scenario do
+testConsumerCanClaimStalePublication : Script ()
+testConsumerCanClaimStalePublication = script do
   (reference, currentObservation, operator, endUserParty, mdvCon1Relation, now, afterExpiry, currentTimeCid, mdVendorParty, mdvStreamId, staleHours)
     <- roleSetup
 
@@ -62,27 +64,29 @@ testConsumerCanClaimStalePublication = scenario do
     afterStale = addRelTime now (hours (staleHours + 1))
     someCleanValue = CleanPrice with clean = 4.0
 
-  submit mdVendorParty do
-    mdvStreamId <- exercise mdvStreamId StartDataStream with
+
+  mdvStreamId <- submit mdVendorParty do
+    exerciseCmd mdvStreamId StartDataStream with
       newObservation = currentObservation
-    exercise mdvStreamId UpdateObservation with
+  submit mdVendorParty do
+    exerciseCmd mdvStreamId UpdateObservation with
       time = now
       newValue = someCleanValue
 
   submit operator do
-    exercise currentTimeCid UpdateCurrentTime with newCurrentTime = afterStale
+    exerciseCmd currentTimeCid UpdateCurrentTime with newCurrentTime = afterStale
 
-  submit endUserParty do
-    (licenseId, license) <- fetchByKey @LiveStreamLicense lookupKey
-    (publicationId, publication) <- fetchByKey @Publication lookupKey
-    stalePublicationCid <- exercise licenseId ClaimStale with publicationId
-    stalePublication <- fetch stalePublicationCid
-    stalePublication.licenseData === license.licenseData
-    stalePublication.publication === publication
-    stalePublication.claimed === afterStale
+  Some (licenseId, license) <- queryContractKey @LiveStreamLicense endUserParty lookupKey
+  Some (publicationId, publication) <- queryContractKey @Publication endUserParty lookupKey
+  stalePublicationCid <-  submit endUserParty do
+    exerciseCmd licenseId ClaimStale with publicationId
+  Some stalePublication <- queryContractId endUserParty stalePublicationCid
+  stalePublication.licenseData === license.licenseData
+  stalePublication.publication === publication
+  stalePublication.claimed === afterStale
 
-testConsumerCannotClaimStalePublicationBeforeStaleTime : Scenario ()
-testConsumerCannotClaimStalePublicationBeforeStaleTime = scenario do
+testConsumerCannotClaimStalePublicationBeforeStaleTime : Script ()
+testConsumerCannotClaimStalePublicationBeforeStaleTime = script do
   (reference, currentObservation, operator, endUserParty, mdvCon1Relation, now, afterExpiry, currentTimeCid, mdVendorParty, mdvStreamId, staleHours)
     <- roleSetup
 
@@ -91,20 +95,19 @@ testConsumerCannotClaimStalePublicationBeforeStaleTime = scenario do
     beforeStale = addRelTime now (hours (staleHours - 1))
     someCleanValue = CleanPrice with clean = 4.0
 
-  submit mdVendorParty do
-    mdvStreamId <- exercise mdvStreamId StartDataStream with
+  mdvStreamId <- submit mdVendorParty do
+    exerciseCmd mdvStreamId StartDataStream with
       newObservation = currentObservation
-    exercise mdvStreamId UpdateObservation with
+  submit mdVendorParty do
+    exerciseCmd mdvStreamId UpdateObservation with
       time = now
       newValue = someCleanValue
 
   submit operator do
-    exercise currentTimeCid UpdateCurrentTime with newCurrentTime = beforeStale
+    exerciseCmd currentTimeCid UpdateCurrentTime with newCurrentTime = beforeStale
 
-  (licenseId, publicationId) <- submit endUserParty do
-    (licenseId, _) <- fetchByKey @LiveStreamLicense lookupKey
-    (publicationId, _) <- fetchByKey @Publication lookupKey
-    pure (licenseId, publicationId)
+  Some (licenseId, _) <- queryContractKey @LiveStreamLicense endUserParty lookupKey
+  Some (publicationId, _) <- queryContractKey @Publication endUserParty lookupKey
 
   submitMustFail endUserParty do
-    exercise licenseId ClaimStale with publicationId
+    exerciseCmd licenseId ClaimStale with publicationId

--- a/src/main/daml/Test/DA/RefApps/MarketDataService/ExpirationTest.daml
+++ b/src/main/daml/Test/DA/RefApps/MarketDataService/ExpirationTest.daml
@@ -10,6 +10,7 @@ import DA.Assert
 import DA.Time qualified as T
 import DA.Date
 import DA.TimeService.TimeService
+import Daml.Script
 
 import DA.RefApps.MarketDataService.DataLicense
 import DA.RefApps.MarketDataService.DataStream
@@ -17,91 +18,92 @@ import DA.RefApps.MarketDataService.MarketDataTypes
 import DA.RefApps.MarketDataService.Publication
 
 import Test.DA.RefApps.MarketDataService.RolesTest
+import Test.DA.RefApps.MarketDataService.Utils
 
-testLicenseExpiryClosesNonFreshStream : Scenario ()
-testLicenseExpiryClosesNonFreshStream = scenario do
+testLicenseExpiryClosesNonFreshStream : Script ()
+testLicenseExpiryClosesNonFreshStream = script do
   (reference, currentObservation, operator, endUserParty, mdvCon1Relation, now, afterExpiry, currentTimeCid, mdVendorParty, mdvStreamId, _)
     <- roleSetup
   mdvStreamId <- submit mdVendorParty $
-    exercise mdvStreamId StartDataStream with
+    exerciseCmd mdvStreamId StartDataStream with
       newObservation = currentObservation
 
   currentTime <- submit operator do
-    exercise currentTimeCid UpdateCurrentTime with newCurrentTime = afterExpiry
+    exerciseCmd currentTimeCid UpdateCurrentTime with newCurrentTime = afterExpiry
 
-  submit mdVendorParty do
-    mdvStreamId <- exercise mdvStreamId UpdateObservation with
+  mdvStreamId <- submit mdVendorParty do
+    exerciseCmd mdvStreamId UpdateObservation with
       time = now
       newValue = CleanPrice with clean = 4.0
-    mdvStream <- fetch mdvStreamId
-    mdvStream.consumers === []
+  Some mdvStream <- queryContractId mdVendorParty mdvStreamId
+  mdvStream.consumers === []
 
   let
     publisher = Publisher mdVendorParty
     consumer = Consumer endUserParty
     lookupKey = (publisher, consumer, reference)
 
-  publication <- submit mdVendorParty do lookupByKey @Publication lookupKey
+  publication <- queryContractKey @Publication mdVendorParty lookupKey
   case publication of
     Some _ -> fail "unexpected contract: Publication should have been closed"
     None -> pure ()
 
-  liveStreamLicense <- submit mdVendorParty do lookupByKey @LiveStreamLicense lookupKey
+  liveStreamLicense <- queryContractKey @LiveStreamLicense mdVendorParty lookupKey
   case liveStreamLicense of
     Some _ -> fail "unexpected contract: LiveStreamLicense should have been expired"
     None -> pure ()
 
-testLicenseExpiryPreventsStartingStream : Scenario ()
-testLicenseExpiryPreventsStartingStream = scenario do
+testLicenseExpiryPreventsStartingStream : Script ()
+testLicenseExpiryPreventsStartingStream = script do
   (reference, currentObservation, operator,  _, _, now, afterExpiry, currentTimeCid, mdVendorParty, mdvStreamId, _)
     <- roleSetup
 
   currentTime <- submit operator do
-    exercise currentTimeCid UpdateCurrentTime with newCurrentTime = afterExpiry
+    exerciseCmd currentTimeCid UpdateCurrentTime with newCurrentTime = afterExpiry
 
   submitMustFail mdVendorParty do
-    exercise mdvStreamId StartDataStream with
+    exerciseCmd mdvStreamId StartDataStream with
       newObservation = currentObservation
 
-testLicenseExpiryClosesFreshStream : Scenario ()
-testLicenseExpiryClosesFreshStream = scenario do
+testLicenseExpiryClosesFreshStream : Script ()
+testLicenseExpiryClosesFreshStream = script do
   (reference, currentObservation, operator, endUserParty, mdvCon1Relation, now, afterExpiry, currentTimeCid, mdVendorParty, mdvStreamId, _)
     <- roleSetup
   mdvStreamId <- submit mdVendorParty $
-    exercise mdvStreamId StartDataStream with
+    exerciseCmd mdvStreamId StartDataStream with
       newObservation = currentObservation
 
   currentTime <- submit operator do
-    exercise currentTimeCid UpdateCurrentTime with newCurrentTime = afterExpiry
+    exerciseCmd currentTimeCid UpdateCurrentTime with newCurrentTime = afterExpiry
 
-  submit mdVendorParty do
-    mdvStreamId <- exercise mdvStreamId UpdateLicenses
-    mdvStream <- fetch mdvStreamId
-    mdvStream.consumers === []
+  mdvStreamId <- submit mdVendorParty do
+    exerciseCmd mdvStreamId UpdateLicenses
+  Some mdvStream <- queryContractId mdVendorParty mdvStreamId
+  mdvStream.consumers === []
 
   let
     publisher = Publisher mdVendorParty
     consumer = Consumer endUserParty
     lookupKey = (publisher, consumer, reference)
 
-  publication <- submit mdVendorParty do lookupByKey @Publication lookupKey
+  publication <- queryContractKey @Publication mdVendorParty lookupKey
   case publication of
     Some _ -> fail "unexpected contract: Publication should have been closed"
     None -> pure ()
 
-  liveStreamLicense <- submit mdVendorParty do lookupByKey @LiveStreamLicense lookupKey
+  liveStreamLicense <- queryContractKey @LiveStreamLicense mdVendorParty lookupKey
   case liveStreamLicense of
     Some _ -> fail "unexpected contract: LiveStreamLicense should have been expired"
     None -> pure ()
 
-testCheckIsExpire : Scenario ()
-testCheckIsExpire = scenario $ do
-  operator <- getParty "Operator"
-  party1 <- getParty "Party1"
-  party2 <- getParty "Party1"
+testCheckIsExpire : Script ()
+testCheckIsExpire = script $ do
+  operator <- allocateParty "Operator"
+  party1 <- allocateParty "Party1"
+  party2 <- allocateParty "Party1"
 
   currentTimeCid <- submit operator do
-    create CurrentTime with
+    createCmd CurrentTime with
       operator = operator
       currentTime = appStartTime
       observers = [operator, party1, party2]
@@ -120,9 +122,9 @@ testCheckIsExpire = scenario $ do
         stale = T.hours 1
         price = SubscriptionFee 1.0
         operator = operator
-  result <- submit party1 $ checkIsExpired operator licenseData
+  result <- checkIsExpiredScript party1 operator licenseData
   assertMsg "License should not be expired." $ not result
 
-  submit operator $ exercise currentTimeCid UpdateCurrentTime with newCurrentTime = futureTime
-  result <- submit party1 $ checkIsExpired operator licenseData
+  submit operator $ exerciseCmd currentTimeCid UpdateCurrentTime with newCurrentTime = futureTime
+  result <- checkIsExpiredScript party1 operator licenseData
   assertMsg "License should be expired." $ result

--- a/src/main/daml/Test/DA/RefApps/MarketDataService/MarketSetupTest.daml
+++ b/src/main/daml/Test/DA/RefApps/MarketDataService/MarketSetupTest.daml
@@ -9,18 +9,20 @@ module Test.DA.RefApps.MarketDataService.MarketSetupTest where
 import DA.Time as T
 import DA.TimeService.TimeService
 
+import Daml.Script
+
 import DA.RefApps.MarketDataService.MarketDataTypes
 import DA.RefApps.MarketDataService.DataLicense
 import DA.RefApps.MarketDataService.Roles
 
-marketSetupScenario : Scenario ()
-marketSetupScenario = scenario do
-  operator <- getParty "Operator"
-  marketDataProvider1Party <- getParty "MarketDataProvider1"
-  marketDataProvider2Party <- getParty "MarketDataProvider2"
-  marketDataVendorParty <- getParty "MarketDataVendor"
-  analyticsVendorParty <- getParty "AnalyticsVendor"
-  endUserParty <- getParty "EndUser"
+marketSetupScript : Script ()
+marketSetupScript = script do
+  operator <- allocateParty "Operator"
+  marketDataProvider1Party <- allocateParty "MarketDataProvider1"
+  marketDataProvider2Party <- allocateParty "MarketDataProvider2"
+  marketDataVendorParty <- allocateParty "MarketDataVendor"
+  analyticsVendorParty <- allocateParty "AnalyticsVendor"
+  endUserParty <- allocateParty "EndUser"
   let starting = addRelTime appStartTime (hours 1)
       ending = addRelTime appStartTime (days 10)
       staleHours = 3
@@ -37,39 +39,39 @@ marketSetupScenario = scenario do
 
   debug "Creating current time"
   currentTimeCid <- submit operator do
-    create CurrentTime with
+    createCmd CurrentTime with
       operator = operator
       currentTime = appStartTime
       observers = [marketDataProvider1Party, marketDataProvider2Party, marketDataVendorParty, analyticsVendorParty, endUserParty]
 
   debug "Creating time configuration"
   timeConfigurationCid <- submit operator do
-    create TimeConfiguration with
+    createCmd TimeConfiguration with
       operator = operator
       isRunning = False
       modelPeriodTime = hours 2
 
   debug "Creating time manager"
   timeManagerCid <- submit operator do
-    create TimeManager with
+    createCmd TimeManager with
             operator = operator
 
   debug "Creating operator role"
-  operatorRole <- submit operator $ create (OperatorRole with operator = operator)
+  operatorRole <- submit operator $ createCmd (OperatorRole with operator = operator)
 
   debug "Loading CSV data sources"
-  providerRoleInvitation <- operator `submit` exercise operatorRole
+  providerRoleInvitation <- operator `submit` exerciseCmd operatorRole
     InviteMarketDataProvider with marketDataProvider = marketDataProvider1Party
-  mdp1ProviderRole <- marketDataProvider1Party `submit` exercise providerRoleInvitation MarketDataProviderInvitation_Accept
-  marketDataProvider1Party `submit` exercise mdp1ProviderRole
+  mdp1ProviderRole <- marketDataProvider1Party `submit` exerciseCmd providerRoleInvitation MarketDataProviderInvitation_Accept
+  marketDataProvider1Party `submit` exerciseCmd mdp1ProviderRole
     LoadCsvDataFromPath with
       reference = reference1
       path = "default-1.csv"
 
-  providerRoleInvitation <- operator `submit` exercise operatorRole
+  providerRoleInvitation <- operator `submit` exerciseCmd operatorRole
     InviteMarketDataProvider with marketDataProvider = marketDataProvider2Party
-  mdp2ProviderRole <- marketDataProvider2Party `submit` exercise providerRoleInvitation MarketDataProviderInvitation_Accept
-  marketDataProvider2Party `submit` exercise mdp2ProviderRole
+  mdp2ProviderRole <- marketDataProvider2Party `submit` exerciseCmd providerRoleInvitation MarketDataProviderInvitation_Accept
+  marketDataProvider2Party `submit` exerciseCmd mdp2ProviderRole
     LoadCsvDataFromPath with
         reference = reference2
         path = "default-1000.csv"
@@ -91,27 +93,27 @@ marketSetupScenario = scenario do
 
 createDataStream : Party -> Party -> (ContractId PublisherConsumerRelationship, ContractId PublisherRole) ->
                    ObservationReference -> Time -> Time -> Int ->
-                   Scenario (ContractId DataLicense)
+                   Script (ContractId DataLicense)
 createDataStream publisher consumer (relationship, pubRole) reference starting ending staleHours = do
   let price = SubscriptionFee 10.000
   debug ("Creating data stream: publisher=" <> (show publisher) <> ", consumer=" <> (show consumer))
-  request <- consumer `submit` exercise relationship RequestStream
+  request <- consumer `submit` exerciseCmd relationship RequestStream
     with reference, starting, ending, staleHours
-  proposal <- publisher `submit` exercise request DataStreamRequest_Propose with price
-  license <- consumer `submit` exercise proposal DataLicenseProposal_Accept
-  stream <- publisher `submit` exercise pubRole RegisterLicense with licenseId = license
+  proposal <- publisher `submit` exerciseCmd request DataStreamRequest_Propose with price
+  license <- consumer `submit` exerciseCmd proposal DataLicenseProposal_Accept
+  stream <- publisher `submit` exerciseCmd pubRole RegisterLicense with licenseId = license
   debug "Created data stream."
   pure license
 
 createRelationship : Party -> ContractId OperatorRole -> Party -> Party
-                    -> Scenario (ContractId PublisherConsumerRelationship, ContractId PublisherRole)
+                    -> Script (ContractId PublisherConsumerRelationship, ContractId PublisherRole)
 createRelationship operator operatorRole publisher consumer = do
   let p = Publisher with party = publisher
       c = Consumer with party = consumer
   debug ("Creating relationship: publisher=" <> (show publisher) <> ", consumer=" <> (show consumer))
-  (relationRequest, roleRequest) <- operator `submit` exercise operatorRole InvitePublisherConsumer with publisher = p, consumer = c
-  publisherAccept <- publisher `submit` exercise relationRequest PublisherInvitation_Accept
-  publisherRole <- publisher `submit` exercise roleRequest PublisherRoleInvitation_Accept
-  relationship <- consumer `submit` exercise publisherAccept ConsumerInvitation_Accept
+  (relationRequest, roleRequest) <- operator `submit` exerciseCmd operatorRole InvitePublisherConsumer with publisher = p, consumer = c
+  publisherAccept <- publisher `submit` exerciseCmd relationRequest PublisherInvitation_Accept
+  publisherRole <- publisher `submit` exerciseCmd roleRequest PublisherRoleInvitation_Accept
+  relationship <- consumer `submit` exerciseCmd publisherAccept ConsumerInvitation_Accept
   debug "Created relationship."
   pure (relationship, publisherRole)

--- a/src/main/daml/Test/DA/RefApps/MarketDataService/RenewalTest.daml
+++ b/src/main/daml/Test/DA/RefApps/MarketDataService/RenewalTest.daml
@@ -9,6 +9,7 @@ module Test.DA.RefApps.MarketDataService.RenewalTest where
 import DA.Assert
 import DA.TimeService.TimeService
 import DA.Time as T
+import Daml.Script
 
 import DA.RefApps.MarketDataService.DataStream
 import DA.RefApps.MarketDataService.MarketDataTypes
@@ -16,12 +17,12 @@ import DA.RefApps.MarketDataService.MarketDataTypes
 import Test.DA.RefApps.MarketDataService.RolesTest
 import Test.DA.RefApps.MarketDataService.Utils
 
-testLicenseRenewal : Scenario ()
-testLicenseRenewal = scenario do
+testLicenseRenewal : Script ()
+testLicenseRenewal = script do
   (reference, currentObservation, operator, endUserParty, mdvCon1Relation, now, afterExpiry, currentTimeCid, mdVendorParty, mdvStreamId, _)
     <- roleSetup
   mdvStreamId <- submit mdVendorParty $
-    exercise mdvStreamId StartDataStream with
+    exerciseCmd mdvStreamId StartDataStream with
       newObservation = currentObservation
 
   let
@@ -29,14 +30,14 @@ testLicenseRenewal = scenario do
     staleHours = 3
     someCleanValue = CleanPrice with clean = 4.0
   currentTime <- submit operator do
-    exercise currentTimeCid UpdateCurrentTime with newCurrentTime = afterExpiry
+    exerciseCmd currentTimeCid UpdateCurrentTime with newCurrentTime = afterExpiry
 
-  submit mdVendorParty do
-    mdvStreamId <- exercise mdvStreamId UpdateObservation with
+  mdvStreamId <- submit mdVendorParty do
+    exerciseCmd mdvStreamId UpdateObservation with
       time = now
       newValue = someCleanValue
-    mdvStream <- fetch mdvStreamId
-    mdvStream.consumers === []
+  Some mdvStream <- queryContractId mdVendorParty mdvStreamId
+  mdvStream.consumers === []
 
   createDataStream
     mdVendorParty endUserParty mdvCon1Relation
@@ -46,11 +47,11 @@ testLicenseRenewal = scenario do
     lookupKey = (Publisher mdVendorParty, reference)
     newObservationValue = someCleanValue
 
-  submit mdVendorParty do
-    (renewedStreamId, _) <- fetchByKey @DataStream lookupKey
-    renewedStreamId <- exercise renewedStreamId UpdateObservation with
+  Some (renewedStreamId, _) <- queryContractKey @DataStream mdVendorParty lookupKey
+  renewedStreamId <- submit mdVendorParty do
+    exerciseCmd renewedStreamId UpdateObservation with
       time = now
       newValue = newObservationValue
-    renewedStream <- fetch renewedStreamId
-    renewedStream.consumers === [Consumer endUserParty]
-    renewedStream.observation.value === newObservationValue
+  Some renewedStream <- queryContractId mdVendorParty renewedStreamId
+  renewedStream.consumers === [Consumer endUserParty]
+  renewedStream.observation.value === newObservationValue

--- a/src/main/daml/Test/DA/RefApps/MarketDataService/RolesTest.daml
+++ b/src/main/daml/Test/DA/RefApps/MarketDataService/RolesTest.daml
@@ -10,6 +10,8 @@ import DA.Date
 import DA.Time as T
 import DA.TimeService.TimeService
 
+import Daml.Script
+
 import DA.RefApps.MarketDataService.DataStream
 import DA.RefApps.MarketDataService.MarketDataTypes
 import DA.RefApps.MarketDataService.Roles
@@ -18,28 +20,28 @@ import Test.DA.RefApps.MarketDataService.Utils
 
 
 roleSetup :
-  Scenario (
+  Script (
     ObservationReference, Observation, Party, Party,
     (ContractId PublisherConsumerRelationship, ContractId PublisherRole),
     Time, Time, ContractId CurrentTime, Party, ContractId EmptyDataStream, Int)
-roleSetup = scenario do
-  operator                <- getParty "Operator"
-  marketDataVendorParty   <- getParty "MarketDataVendor"
-  endUserParty           <- getParty "EndUser"
+roleSetup = script do
+  operator                <- allocateParty "Operator"
+  marketDataVendorParty   <- allocateParty "MarketDataVendor"
+  endUserParty           <- allocateParty "EndUser"
 
   let today = date 2019 Nov 12
       now = T.time today 14 57 0
   currentTimeCid <- operator `submit`
-    create CurrentTime with
+    createCmd CurrentTime with
       operator
       currentTime = now
       observers = [marketDataVendorParty, endUserParty]
 
-  operatorRole <- operator `submit` create OperatorRole with operator
+  operatorRole <- operator `submit` createCmd OperatorRole with operator
 
   mdvCon1Relation <- createRelationship operator operatorRole marketDataVendorParty endUserParty
 
-  now <- submit operator $ fetchTime operator
+  now <- fetchTimeScript operator operator
   let
     isin = InstrumentId "ISIN 123 XYZ"
     reference = ObservationReference

--- a/src/main/daml/Test/DA/RefApps/MarketDataService/Triggers/EnrichmentTest.daml
+++ b/src/main/daml/Test/DA/RefApps/MarketDataService/Triggers/EnrichmentTest.daml
@@ -10,6 +10,7 @@ import DA.Assert
 import DA.Date
 import DA.Next.Map
 import DA.Time as T
+import Daml.Script
 import Daml.Trigger.Assert
 
 import DA.TimeService.TimeService
@@ -19,26 +20,27 @@ import DA.RefApps.MarketDataService.Triggers.Enrichment
 import DA.RefApps.MarketDataService.MarketDataTypes
 import DA.RefApps.MarketDataService.Roles
 import Test.DA.RefApps.MarketDataService.MarketSetupTest
+import Test.DA.RefApps.MarketDataService.Utils (queryContractKey)
 
 coupons : [Date]
 coupons = [date 2019 Feb 20, date 2020 Feb 20]
 
-testNextCouponDateAfter : Scenario ()
-testNextCouponDateAfter = scenario do
+testNextCouponDateAfter : Script ()
+testNextCouponDateAfter = script do
   Some (date 2019 Feb 20) === nextCouponDateAfter (date 2019 Jan 20) coupons
   Some (date 2020 Feb 20) === nextCouponDateAfter (date 2020 Jan 20) coupons
   None === nextCouponDateAfter (date 2021 Jan 20) coupons
 
-testAccruedInterestBetween : Scenario ()
-testAccruedInterestBetween = scenario do
+testAccruedInterestBetween : Script ()
+testAccruedInterestBetween = script do
   0.0 === accruedInterestBetween (date 2020 Feb 20) (date 2020 Feb 20) 1.0
   1.0/365.0 === accruedInterestBetween (date 2020 Feb 19) (date 2020 Feb 20) 1.0
   31.0/365.0 === accruedInterestBetween (date 2020 Jan 20) (date 2020 Feb 20) 1.0
   364.0/365.0 === accruedInterestBetween (date 2019 Feb 21) (date 2020 Feb 20) 1.0
   1.0 === accruedInterestBetween (date 2019 Feb 20) (date 2020 Feb 20) 1.0
 
-testAccruedInterest : Scenario ()
-testAccruedInterest = scenario do
+testAccruedInterest : Script ()
+testAccruedInterest = script do
   let
     bond = BondInfo
       with
@@ -55,16 +57,16 @@ testReference = ObservationReference with
   instrumentId = InstrumentId "Test Reference"
   maturityDate = date 1997 Aug 29
 
-observationHasNotChangedWhenValuesAreEqual : Scenario ()
-observationHasNotChangedWhenValuesAreEqual = scenario do
+observationHasNotChangedWhenValuesAreEqual : Script ()
+observationHasNotChangedWhenValuesAreEqual = script do
   let o = Observation with
         label = testReference
         time = T.time (date 1997 Aug 4) 12 23 45
         value = CleanPrice with clean = 1.0
   False === observationHasChanged o o
 
-observationHasNotChangedWhenTimeRemains : Scenario ()
-observationHasNotChangedWhenTimeRemains = scenario do
+observationHasNotChangedWhenTimeRemains : Script ()
+observationHasNotChangedWhenTimeRemains = script do
   let o1 = Observation with
         label = testReference
         time = T.time (date 1997 Aug 4) 12 23 45
@@ -75,8 +77,8 @@ observationHasNotChangedWhenTimeRemains = scenario do
         value = CleanPrice with clean = 2.0
   False === observationHasChanged o1 o2
 
-observationHasNotChangedWhenTimeIsOlderAndValueChanged : Scenario ()
-observationHasNotChangedWhenTimeIsOlderAndValueChanged = scenario do
+observationHasNotChangedWhenTimeIsOlderAndValueChanged : Script ()
+observationHasNotChangedWhenTimeIsOlderAndValueChanged = script do
   let o1 = Observation with
         label = testReference
         time = T.time (date 1997 Aug 4) 12 23 45
@@ -87,8 +89,8 @@ observationHasNotChangedWhenTimeIsOlderAndValueChanged = scenario do
         value = CleanPrice with clean = 2.0
   False === observationHasChanged o1 o2
 
-observationHasChangedWhenTimeIsNewerAndValueRemains : Scenario ()
-observationHasChangedWhenTimeIsNewerAndValueRemains = scenario do
+observationHasChangedWhenTimeIsNewerAndValueRemains : Script ()
+observationHasChangedWhenTimeIsNewerAndValueRemains = script do
   let o1 = Observation with
         label = testReference
         time = T.time (date 1997 Aug 4) 12 23 45
@@ -99,8 +101,8 @@ observationHasChangedWhenTimeIsNewerAndValueRemains = scenario do
         value = CleanPrice with clean = 1.0
   True === observationHasChanged o1 o2
 
-observationHasChangedWhenTimeIsNewerAndValueChanged : Scenario ()
-observationHasChangedWhenTimeIsNewerAndValueChanged = scenario do
+observationHasChangedWhenTimeIsNewerAndValueChanged : Script ()
+observationHasChangedWhenTimeIsNewerAndValueChanged = script do
   let o1 = Observation with
         label = testReference
         time = T.time (date 1997 Aug 4) 12 23 45
@@ -112,13 +114,13 @@ observationHasChangedWhenTimeIsNewerAndValueChanged = scenario do
   True === observationHasChanged o1 o2
 
 -- fixing ERA-712
-publicationRuleEmitsOnlyOneExerciseCommandPerDataStream: Scenario ()
-publicationRuleEmitsOnlyOneExerciseCommandPerDataStream = scenario do
-  operator <- getParty "Operator"
-  marketDataVendor <- getParty "MarketDataVendor"
-  marketDataProvider1 <- getParty "MarketDataProvider1"
-  marketDataProvider2 <- getParty "MarketDataProvider2"
-  analyticsVendor <- getParty "AnalyticsVendor"
+publicationRuleEmitsOnlyOneExerciseCommandPerDataStream: Script ()
+publicationRuleEmitsOnlyOneExerciseCommandPerDataStream = script do
+  operator <- allocateParty "Operator"
+  marketDataVendor <- allocateParty "MarketDataVendor"
+  marketDataProvider1 <- allocateParty "MarketDataProvider1"
+  marketDataProvider2 <- allocateParty "MarketDataProvider2"
+  analyticsVendor <- allocateParty "AnalyticsVendor"
 
   let
     starting = addRelTime appStartTime (hours 1)
@@ -147,20 +149,20 @@ publicationRuleEmitsOnlyOneExerciseCommandPerDataStream = scenario do
         value = CleanPrice with clean = 3.0
 
   currentTimeCid <- submit operator do
-    create CurrentTime with
+    createCmd CurrentTime with
       operator = operator
       currentTime = appStartTime
       observers = [marketDataVendor]
 
-  operatorRole <- submit operator $ create (OperatorRole with operator = operator)
+  operatorRole <- submit operator $ createCmd (OperatorRole with operator = operator)
   mdvAnvRelation <- createRelationship operator operatorRole marketDataVendor analyticsVendor
   createDataStream marketDataVendor analyticsVendor mdvAnvRelation usReference starting ending staleHours
+  Some (edsUsCid, _) <- queryContractKey @EmptyDataStream marketDataVendor (Publisher marketDataVendor, usReference)
   dataStreamUs <- submit marketDataVendor do
-    (edsUsCid, _) <- fetchByKey @EmptyDataStream (Publisher marketDataVendor, usReference)
-    exercise edsUsCid StartDataStream with newObservation = usObservation
+    exerciseCmd edsUsCid StartDataStream with newObservation = usObservation
 
   publicationUs <- submit marketDataProvider1 do
-    create Publication
+    createCmd Publication
       with
         observation = usObservation
         publisher = Publisher marketDataProvider1
@@ -169,7 +171,7 @@ publicationRuleEmitsOnlyOneExerciseCommandPerDataStream = scenario do
         operator
 
   publicationEu <- submit marketDataProvider2 do
-    create Publication
+    createCmd Publication
       with
         observation = euObservation
         publisher = Publisher marketDataProvider2
@@ -177,12 +179,9 @@ publicationRuleEmitsOnlyOneExerciseCommandPerDataStream = scenario do
         published
         operator
 
-  currentTime <- submit operator do
-    (currentTimeCid, currentTime) <- fetchByKey @CurrentTime operator
-    exercise currentTimeCid UpdateCurrentTime
-      with
-        newCurrentTime = addRelTime currentTime.currentTime $ hours 1
 
+  currentTime <- submit operator do
+    exerciseCmd currentTimeCid (AdvanceByCurrentTime $ hours 1)
   let
     activeContracts = toACS currentTime <> toACS dataStreamUs <> toACS publicationEu <> toACS publicationUs
     commandsInFlight = DA.Next.Map.empty

--- a/src/main/daml/Test/DA/RefApps/MarketDataService/Utils.daml
+++ b/src/main/daml/Test/DA/RefApps/MarketDataService/Utils.daml
@@ -6,26 +6,34 @@
 daml 1.2
 module Test.DA.RefApps.MarketDataService.Utils where
 
+import Daml.Script
+
 import DA.RefApps.MarketDataService.MarketDataTypes
 import DA.RefApps.MarketDataService.Roles
 
 createRelationship : Party -> ContractId OperatorRole -> Party -> Party
-                  -> Scenario (ContractId PublisherConsumerRelationship, ContractId PublisherRole)
+                  -> Script (ContractId PublisherConsumerRelationship, ContractId PublisherRole)
 createRelationship operator operatorRole publisher consumer = do
   let p = Publisher with party = publisher
       c = Consumer with party = consumer
-  (relationRequest, roleRequest) <- operator `submit` exercise operatorRole InvitePublisherConsumer with publisher = p, consumer = c
-  publisherAccept <- publisher `submit` exercise relationRequest PublisherInvitation_Accept
-  publisherRole <- publisher `submit` exercise roleRequest PublisherRoleInvitation_Accept
-  relationship <- consumer `submit` exercise publisherAccept ConsumerInvitation_Accept
+  (relationRequest, roleRequest) <- operator `submit` exerciseCmd operatorRole InvitePublisherConsumer with publisher = p, consumer = c
+  publisherAccept <- publisher `submit` exerciseCmd relationRequest PublisherInvitation_Accept
+  publisherRole <- publisher `submit` exerciseCmd roleRequest PublisherRoleInvitation_Accept
+  relationship <- consumer `submit` exerciseCmd publisherAccept ConsumerInvitation_Accept
   return (relationship, publisherRole)
 
 createDataStream : Party -> Party -> (ContractId PublisherConsumerRelationship, ContractId PublisherRole) ->
                    ObservationReference -> Time -> Time -> Int -> SubscriptionFee ->
-                   Scenario SomeDataStream
+                   Script SomeDataStream
 createDataStream publisher consumer (relationship, pubRole) reference starting ending staleHours price = do
-  request <- consumer `submit` exercise relationship RequestStream
+  request <- consumer `submit` exerciseCmd relationship RequestStream
     with reference, starting, ending, staleHours
-  proposal <- publisher `submit` exercise request DataStreamRequest_Propose with price
-  license <- consumer `submit` exercise proposal DataLicenseProposal_Accept
-  publisher `submit` exercise pubRole RegisterLicense with licenseId = license
+  proposal <- publisher `submit` exerciseCmd request DataStreamRequest_Propose with price
+  license <- consumer `submit` exerciseCmd proposal DataLicenseProposal_Accept
+  publisher `submit` exerciseCmd pubRole RegisterLicense with licenseId = license
+
+-- Might move into daml-stdlib
+queryContractKey : forall t k. (TemplateKey t k, Eq k) => Party -> k -> Script (Optional (ContractId t, t))
+queryContractKey p k =
+  find (\(_, t) -> key t == k) <$>
+  query @t p

--- a/src/main/daml/Test/DA/TimeService/TimeServiceTest.daml
+++ b/src/main/daml/Test/DA/TimeService/TimeServiceTest.daml
@@ -1,5 +1,5 @@
 --
--- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 --
 

--- a/src/main/daml/Test/DA/TimeService/TimeServiceTest.daml
+++ b/src/main/daml/Test/DA/TimeService/TimeServiceTest.daml
@@ -1,15 +1,16 @@
 --
--- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 --
 
-daml 1.2
+{-# LANGUAGE ApplicativeDo #-}
 module Test.DA.TimeService.TimeServiceTest where
 
 import DA.Time
 import DA.Date
 import DA.Assert
 import DA.TimeService.TimeService
+import Daml.Script
 
 data TestData = TestData with
   operator: Party
@@ -21,10 +22,10 @@ data TestData = TestData with
   configuration: ContractId TimeConfiguration
   manager: ContractId TimeManager
 
-setupTimeTestWithAlice : Scenario TestData
-setupTimeTestWithAlice = scenario do
-  operator <- getParty "Operator"
-  alice <- getParty "Alice"
+setupTimeTestWithAlice : Script TestData
+setupTimeTestWithAlice = script do
+  operator <- allocateParty "Operator"
+  alice <- allocateParty "Alice"
   let
     today = date 2019 Nov 12
     now = time today 14 57 0
@@ -32,25 +33,25 @@ setupTimeTestWithAlice = scenario do
     later = addRelTime now modelPeriodTime
   now =/= later
   currentTime <- submit operator do
-    create CurrentTime with
+    createCmd CurrentTime with
       operator = operator
       currentTime = now
       observers = [alice]
   configuration <- submit operator do
-    create TimeConfiguration with
+    createCmd TimeConfiguration with
       operator = operator
       isRunning = True
       modelPeriodTime
   manager <- submit operator do
-    create TimeManager with
+    createCmd TimeManager with
       operator = operator
   return TestData with ..
 
-testTwoConcurrentTimeServicesWithDifferentKeysShowDifferentTime : Scenario ()
-testTwoConcurrentTimeServicesWithDifferentKeysShowDifferentTime = scenario do
+testTwoConcurrentTimeServicesWithDifferentKeysShowDifferentTime : Script ()
+testTwoConcurrentTimeServicesWithDifferentKeysShowDifferentTime = script do
   testData <- setupTimeTestWithAlice
-  operatorForBob <- getParty "OperatorForBob"
-  bob <- getParty "Bob"
+  operatorForBob <- allocateParty "OperatorForBob"
+  bob <- allocateParty "Bob"
   let
     operatorForAlice = testData.operator
     timeAlice = testData.now
@@ -58,139 +59,146 @@ testTwoConcurrentTimeServicesWithDifferentKeysShowDifferentTime = scenario do
   timeAlice =/= timeBob
 
   submit operatorForBob do
-    create CurrentTime with
+    createCmd CurrentTime with
       operator = operatorForBob
       currentTime = timeBob
       observers = [bob]
 
-  submit testData.alice do
-    t <- fetchTime operatorForAlice
-    t === timeAlice
+  t <- submit testData.alice do
+    exerciseByKeyCmd @CurrentTime operatorForAlice (GetCurrentTime testData.alice)
 
-  submit bob do
-    t <- fetchTime operatorForBob
-    t === timeBob
+  t === timeAlice
 
-testTimeNowWorksForEveryObserver : Scenario ()
-testTimeNowWorksForEveryObserver = scenario do
+  t <- submit bob do
+    exerciseByKeyCmd @CurrentTime operatorForBob (GetCurrentTime bob)
+  t === timeBob
+
+testTimeNowWorksForEveryObserver : Script ()
+testTimeNowWorksForEveryObserver = script do
   testData <- setupTimeTestWithAlice
 
-  bob <- getParty "Bob"
+  bob <- allocateParty "Bob"
   currentTime <- submit testData.operator do
-    exercise testData.manager AddObserver with newObserver = bob
+    exerciseCmd testData.manager AddObserver with newObserver = bob
 
-  submit testData.alice do
-    t <- fetchTime testData.operator
-    t === testData.now
+  t <- submit testData.alice do
+    exerciseByKeyCmd @CurrentTime testData.operator (GetCurrentTime testData.alice)
+  t === testData.now
 
-  submit bob do
-    t <- fetchTime testData.operator
-    t === testData.now
+  t <- submit bob do
+    exerciseByKeyCmd @CurrentTime testData.operator (GetCurrentTime bob)
+  t === testData.now
 
   submit testData.operator do
-    exercise testData.manager AdvanceCurrentTime
+    exerciseCmd testData.manager AdvanceCurrentTime
 
-  submit testData.alice do
-    t <- fetchTime testData.operator
-    t === testData.later
+  t <- submit testData.alice do
+    exerciseByKeyCmd @CurrentTime testData.operator (GetCurrentTime testData.alice)
+  t === testData.later
 
-  submit bob do
-    t <- fetchTime testData.operator
-    t === testData.later
+  t <- submit bob do
+    exerciseByKeyCmd @CurrentTime testData.operator (GetCurrentTime bob)
+  t === testData.later
 
-testTimeCannotBeCreatedByOthers : Scenario ()
-testTimeCannotBeCreatedByOthers = scenario do
-  operator <- getParty "Operator"
-  alice <- getParty "Alice"
+testTimeCannotBeCreatedByOthers : Script ()
+testTimeCannotBeCreatedByOthers = script do
+  operator <- allocateParty "Operator"
+  alice <- allocateParty "Alice"
   let
     currentTime = time (date 2019 Nov 12) 14 57 0
 
   submitMustFail alice do
-    create CurrentTime with
+    createCmd CurrentTime with
       operator
       currentTime
       observers = []
 
-testTimeCannotBeManipulatedByOthers : Scenario ()
-testTimeCannotBeManipulatedByOthers = scenario do
+testTimeCannotBeManipulatedByOthers : Script ()
+testTimeCannotBeManipulatedByOthers = script do
   testData <- setupTimeTestWithAlice
   submitMustFail testData.alice do
-    exercise testData.currentTime UpdateCurrentTime with newCurrentTime = testData.later
+    exerciseCmd testData.currentTime UpdateCurrentTime with newCurrentTime = testData.later
   submitMustFail testData.alice do
-    exercise testData.manager SetCurrentTime with newCurrentTime = testData.later
+    exerciseCmd testData.manager SetCurrentTime with newCurrentTime = testData.later
 
-testTimeNotAdvancesWhenStopped : Scenario ()
-testTimeNotAdvancesWhenStopped = scenario do
+testTimeNotAdvancesWhenStopped : Script ()
+testTimeNotAdvancesWhenStopped = script do
   testData <- setupTimeTestWithAlice
 
-  submit testData.operator do
-    exercise testData.manager Stop
-    exercise testData.manager AdvanceCurrentTime
-    t <- fetchTime testData.operator
-    t === testData.now
+  t <- submit testData.operator do
+    exerciseCmd testData.manager Stop
+    exerciseCmd testData.manager AdvanceCurrentTime
+    t <- exerciseByKeyCmd @CurrentTime testData.operator (GetCurrentTime testData.operator)
+    pure t
+  t === testData.now
 
-testTimeCanBeContinued : Scenario ()
-testTimeCanBeContinued = scenario do
+testTimeCanBeContinued : Script ()
+testTimeCanBeContinued = script do
   testData <- setupTimeTestWithAlice
 
-  submit testData.operator do
-    exercise testData.manager Stop
-    exercise testData.manager Continue
-    exercise testData.manager AdvanceCurrentTime
-    t <- fetchTime testData.operator
-    t === testData.later
+  t <- submit testData.operator do
+    exerciseCmd testData.manager Stop
+    exerciseCmd testData.manager Continue
+    exerciseCmd testData.manager AdvanceCurrentTime
+    t <- exerciseByKeyCmd @CurrentTime testData.operator (GetCurrentTime testData.operator)
+    pure t
+  t === testData.later
 
-testSetModelPeriodTime : Scenario ()
-testSetModelPeriodTime = scenario do
+testSetModelPeriodTime : Script ()
+testSetModelPeriodTime = script do
   testData <- setupTimeTestWithAlice
   let
     newModelPeriodTime = minutes 45
     someOtherTime = addRelTime testData.now newModelPeriodTime
 
-  submit testData.operator do
-    exercise testData.manager SetModelPeriodTime with
+  t <- submit testData.operator do
+    exerciseCmd testData.manager SetModelPeriodTime with
       newModelPeriodTime = newModelPeriodTime
-    exercise testData.manager AdvanceCurrentTime
-    t <- fetchTime testData.operator
-    t === someOtherTime
+    exerciseCmd testData.manager AdvanceCurrentTime
+    t <- exerciseByKeyCmd @CurrentTime testData.operator (GetCurrentTime testData.operator)
+    pure t
+  t === someOtherTime
 
-testModelTimeAdvancesContinually : Scenario ()
-testModelTimeAdvancesContinually = scenario do
+testModelTimeAdvancesContinually : Script ()
+testModelTimeAdvancesContinually = script do
   testData <- setupTimeTestWithAlice
   let
     someTime = addRelTime testData.now testData.modelPeriodTime
     afterSomeTime = addRelTime someTime testData.modelPeriodTime
 
-  submit testData.operator do
-    exercise testData.manager AdvanceCurrentTime
-    exercise testData.manager AdvanceCurrentTime
-    t <- fetchTime testData.operator
-    t === afterSomeTime
+  t <- submit testData.operator do
+    exerciseCmd testData.manager AdvanceCurrentTime
+    exerciseCmd testData.manager AdvanceCurrentTime
+    t <- exerciseByKeyCmd @CurrentTime testData.operator (GetCurrentTime testData.operator)
+    pure t
+  t === afterSomeTime
 
-testTimeContractIsUnique : Scenario ()
-testTimeContractIsUnique = scenario do
+testTimeContractIsUnique : Script ()
+testTimeContractIsUnique = script do
   testData <- setupTimeTestWithAlice
 
   submitMustFail testData.operator do
-    create CurrentTime with
+    createCmd CurrentTime with
       operator = testData.operator
       currentTime = testData.now
       observers = []
 
-testUpdateCurrentTime : Scenario ()
-testUpdateCurrentTime = scenario do
+testUpdateCurrentTime : Script ()
+testUpdateCurrentTime = script do
   testData <- setupTimeTestWithAlice
 
-  submit testData.operator do
-    exercise testData.currentTime UpdateCurrentTime with newCurrentTime = testData.later
-    t <- fetchTime testData.operator
-    t === testData.later
+  t <- submit testData.operator do
+    exerciseCmd testData.currentTime UpdateCurrentTime with newCurrentTime = testData.later
+    t <- exerciseByKeyCmd @CurrentTime testData.operator (GetCurrentTime testData.operator)
+    pure t
+  t === testData.later
 
-testSetCurrentTime : Scenario ()
-testSetCurrentTime = scenario do
+testSetCurrentTime : Script ()
+testSetCurrentTime = script do
   testData <- setupTimeTestWithAlice
 
-  submit testData.operator do
-    exercise testData.manager SetCurrentTime with newCurrentTime = testData.later
-    t <- fetchTime testData.operator
-    t === testData.later
+  t <- submit testData.operator do
+    exerciseCmd testData.manager SetCurrentTime with newCurrentTime = testData.later
+    t <- exerciseByKeyCmd @CurrentTime testData.operator (GetCurrentTime testData.operator)
+    pure t
+  t === testData.later

--- a/src/main/java/com/digitalasset/refapps/marketdataservice/Main.java
+++ b/src/main/java/com/digitalasset/refapps/marketdataservice/Main.java
@@ -68,7 +68,7 @@ public class Main {
           new DataProviderBot(parties.getMarketDataProvider1(), dataProvider);
       wire(
           appConfig,
-          dataProviderBot.getPartyName(),
+          dataProviderBot.allocatePartyName(),
           dataProviderBot.getContractQuery(),
           dataProviderBot::getCommands);
     }
@@ -80,7 +80,7 @@ public class Main {
           new DataProviderBot(parties.getMarketDataProvider2(), dataProvider);
       wire(
           appConfig,
-          dataProviderBot.getPartyName(),
+          dataProviderBot.allocatePartyName(),
           dataProviderBot.getContractQuery(),
           dataProviderBot::getCommands);
     }

--- a/src/main/java/com/digitalasset/refapps/marketdataservice/publishing/DataProviderBot.java
+++ b/src/main/java/com/digitalasset/refapps/marketdataservice/publishing/DataProviderBot.java
@@ -56,7 +56,7 @@ public class DataProviderBot {
     return new ContractQuery(templateSet);
   }
 
-  public String getPartyName() {
+  public String allocatePartyName() {
     return partyName;
   }
 


### PR DESCRIPTION
Recreating https://github.com/digital-asset/ex-market-data-service/pull/65


* Migrate scenarios to DAML Script

Yet another one, again a draft because it depends on the migration of
the trigger assertion library.

* Migrate to SDK 1.5.0